### PR TITLE
Resolve boto3 1.36 incompatability with Backblaze

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 git+https://github.com/CCI-MOC/nerc-rates@33701ed#egg=nerc_rates
-boto3 < 1.36
+boto3
 dataclasses-json
 requests

--- a/src/openstack_billing_db/fetch.py
+++ b/src/openstack_billing_db/fetch.py
@@ -6,6 +6,7 @@ import subprocess
 import boto3
 import requests
 from requests.auth import HTTPBasicAuth
+from botocore.config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +60,7 @@ def download_latest_dump_from_s3() -> str:
         endpoint_url=s3_endpoint,
         aws_access_key_id=s3_key_id,
         aws_secret_access_key=s3_secret,
+        config=Config(s3={"use_checksums": False})
     )
 
     key = None


### PR DESCRIPTION
Closes https://github.com/CCI-MOC/openstack-billing-from-db/issues/83. Primary cause is because of checksums introduced in 1.36. By explcitly disabling this feature we retain old functionality and no longer have to pin boto3 to 1.35. In the future, we may want to update this.